### PR TITLE
MueLu/Xpetra: add a check for SerialNode being enabled if Epetra and Tpetra enabled

### DIFF
--- a/packages/muelu/CMakeLists.txt
+++ b/packages/muelu/CMakeLists.txt
@@ -196,7 +196,18 @@ IF(${PACKAGE_NAME}_ENABLE_EXPLICIT_INSTANTIATION)
     GLOBAL_SET (HAVE_${PACKAGE_NAME_UC}_CUDA    ${Tpetra_INST_CUDA})
   ENDIF()
   IF (${PACKAGE_NAME}_ENABLE_Epetra)
-    # If Epetra is active, always activate SerialNode
+    # If Epetra is active, check for Serial node
+    IF (${PACKAGE_NAME_UC}_ENABLE_Tpetra)
+      # Both Epetra and Tpetra are enabled. For Epetra we then need the serial node.
+      # TAW: 11/23/2015 phone conference with JJH and CSF:
+      # Even though Kokkos::SerialNode "should" be sufficient, we request Tpetra also
+      # instantiated on the SerialNode.
+      IF (NOT ${Tpetra_INST_SERIAL})
+        MESSAGE(FATAL_ERROR "If both Epetra and Tpetra are enabled you also have to enable the SerialNode in Tpetra. Please set Tpetra_INST_SERIAL = ON in your configuration.")
+      ENDIF ()
+    ENDIF ()
+    # Enable serial node for Epetra
+    # For the Epetra-only case we use the FakeKokkos Node.
     GLOBAL_SET (HAVE_${PACKAGE_NAME_UC}_SERIAL ON)
   ENDIF ()
   MESSAGE(STATUS "HAVE_${PACKAGE_NAME_UC}_SERIAL       : ${HAVE_${PACKAGE_NAME_UC}_SERIAL}")

--- a/packages/xpetra/CMakeLists.txt
+++ b/packages/xpetra/CMakeLists.txt
@@ -157,7 +157,18 @@ IF (${PACKAGE_NAME}_ENABLE_Tpetra)
   GLOBAL_SET (HAVE_XPETRA_CUDA    ${Tpetra_INST_CUDA})
 ENDIF()
 IF (${PACKAGE_NAME}_ENABLE_Epetra)
-  # If Epetra is active, enable Serial node
+  # If Epetra is active, check for Serial node
+  IF (${PACKAGE_NAME}_ENABLE_Tpetra)
+    # Both Epetra and Tpetra are enabled. For Epetra we then need the serial node.
+    # TAW: 11/23/2015 phone conference with JJH and CSF:
+    # Even though Kokkos::SerialNode "should" be sufficient, we request Tpetra also
+    # instantiated on the SerialNode.
+    IF (NOT ${Tpetra_INST_SERIAL})
+      MESSAGE(FATAL_ERROR "If both Epetra and Tpetra are enabled you also have to enable the SerialNode in Tpetra. Please set Tpetra_INST_SERIAL = ON in your configuration.")
+    ENDIF ()
+  ENDIF ()
+  # Enable serial node for Epetra
+  # For the Epetra-only case we use the FakeKokkos Node.
   GLOBAL_SET (HAVE_XPETRA_SERIAL  ON)
 ENDIF ()
 


### PR DESCRIPTION
Be aware: if SerialNode is disabled, we cannot build with (plain) Epetra any more! To be able to compile plain Epetra and Xpetra with Tpetra (without SerialNode), one has to explicitly turn off Epetra support in Xpetra! I guess, some of Andreys experimental nightly test configurations wouldn't even run through the configuration process any more!